### PR TITLE
Deserializing and Writing Animation on Timeline

### DIFF
--- a/Blender/settings.py
+++ b/Blender/settings.py
@@ -44,6 +44,7 @@ class VpetProperties(bpy.types.PropertyGroup):
     Command_Module_port: bpy.props.StringProperty(default = '5558')
     humanoid_rig: bpy.props.BoolProperty(name="Humanoid Rig for Unity",description="Check if using humanoid rig and you need to send the character to Unity",default=False)
     vpet_collection: bpy.props.StringProperty(name = 'VPET Collection', default = 'VPET_Collection', maxlen=30)
+    overwrite_animation: bpy.props.BoolProperty(name="Overwrite Animation", description="When true, baking an animation received from AnimHost will overwrite the previous one; otherwhise, it writes it on a new layer", default=False)
     #edit_collection: bpy.props.StringProperty(name = 'Editable Collection', default = 'VPET_editable', maxlen=30)
 
 ## Class to keep data


### PR DESCRIPTION
First half of the implementation of #8 
- The Add-On reads and deserializes keyframed animation data sent in block by, for example, AnimHost
- (Re)initialising the animation data of the target character object
- Filling the timeline with the received keyframes
Still missing:
- Button to save and push down the animation in the timeline into the NLA tracks
- Button to request a new animation from AnimHost (RPC Call implementation needed)